### PR TITLE
Relax gnome-shell version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"description": "Integrate github's notifications within the gnome desktop environment", "uuid": "github.notifications@alexandre.dufournet.gmail.com", "name": "Github Notifications", "shell-version": ["3.20.4"]}
+{"description": "Integrate github's notifications within the gnome desktop environment", "uuid": "github.notifications@alexandre.dufournet.gmail.com", "name": "Github Notifications", "shell-version": ["3.20"]}


### PR DESCRIPTION
Currently, trying to install this extension using a non-3.20.4 version
of gnome-shell results in a silent failure and an "outdated" message in
the log window. This change allows the extension to be loaded using any
3.20.x version of gnome-shell. (It's working well for me locally using
3.20.3.)