### PR TITLE
Add missing shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,5 +2,5 @@
 	"description": "Integrate github's notifications within the gnome desktop environment\nSource code is available here: https://github.com/alexduf/gnome-github-notifications",
 	"uuid": "github.notifications@alexandre.dufournet.gmail.com",
 	"name": "Github Notifications",
-	"shell-version": ["3.20", "3.22", "3.24"]
+	"shell-version": ["3.20", "3.22", "3.24", "3.26", "3.28", "3.30", "3.32", "3.34", "3.36", "3.38"]
 }


### PR DESCRIPTION
Following review from gnome, I should probably update the list of supported shells.

For the record I can't test this so here's to hope 🤞 