### PR TITLE
Support gnome 40 (the bare minimum)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,5 +2,5 @@
 	"description": "Integrate github's notifications within the gnome desktop environment\nSource code is available here: https://github.com/alexduf/gnome-github-notifications",
 	"uuid": "github.notifications@alexandre.dufournet.gmail.com",
 	"name": "Github Notifications",
-	"shell-version": ["3.20", "3.22", "3.24", "3.26", "3.28", "3.30", "3.32", "3.34", "3.36", "3.38"]
+	"shell-version": ["3.20", "3.22", "3.24", "3.26", "3.28", "3.30", "3.32", "3.34", "3.36", "3.38", "40"]
 }

--- a/prefs.js
+++ b/prefs.js
@@ -25,71 +25,71 @@ function buildPrefsWidget() {
 
   const hideWidgetBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const hideWidgetLabel = new Gtk.Label({label : "Hide widget when there are no notifications"});
-  hideWidgetBox.append(hideWidgetLabel);
+  hideWidgetBox.prepend(hideWidgetLabel);
   const hideWidgetSwitch = new Gtk.Switch();
   settings.bind('hide-widget', hideWidgetSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
-  hideWidgetBox.prepend(hideWidgetSwitch);
-  box.append(hideWidgetBox);
+  hideWidgetBox.append(hideWidgetSwitch);
+  box.prepend(hideWidgetBox);
 
   const hideCount = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const hideCountLabel = new Gtk.Label({label : "Hide notification count"});
-  hideCount.append(hideCountLabel);
+  hideCount.prepend(hideCountLabel);
   const hideCountSwitch = new Gtk.Switch();
   settings.bind('hide-notification-count', hideCountSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
-  hideCount.prepend(hideCountSwitch);
-  box.append(hideCount);
+  hideCount.append(hideCountSwitch);
+  box.prepend(hideCount);
 
   const showParticipating = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const showParticipatingLabel = new Gtk.Label({label : "Only count notifications if you're participating (mention, review asked...)"});
-  showParticipating.append(showParticipatingLabel);
+  showParticipating.prepend(showParticipatingLabel);
   const showParticipatingSwitch = new Gtk.Switch();
   settings.bind('show-participating-only', showParticipatingSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
-  showParticipating.prepend(showParticipatingSwitch);
-  box.append(showParticipating);
+  showParticipating.append(showParticipatingSwitch);
+  box.prepend(showParticipating);
 
   const refreshInterval = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const refreshIntervalLabel = new Gtk.Label({label : "Refresh interval (in seconds)*"});
-  refreshInterval.append(refreshIntervalLabel);
+  refreshInterval.prepend(refreshIntervalLabel);
   const refreshIntervalSpinButton = Gtk.SpinButton.new_with_range (60, 86400, 1);
   settings.bind('refresh-interval', refreshIntervalSpinButton, 'value', Gio.SettingsBindFlags.DEFAULT);
-  refreshInterval.prepend(refreshIntervalSpinButton);
-  box.append(refreshInterval);
+  refreshInterval.append(refreshIntervalSpinButton);
+  box.prepend(refreshInterval);
 
   // Show Alert
   const showAlert = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const showAlertLabel = new Gtk.Label({label : "Show notifications alert"});
-  showAlert.append(showAlertLabel);
+  showAlert.prepend(showAlertLabel);
   const showAlertSwitch = new Gtk.Switch();
   settings.bind('show-alert', showAlertSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
-  showAlert.prepend(showAlertSwitch);
-  box.append(showAlert);
+  showAlert.append(showAlertSwitch);
+  box.prepend(showAlert);
 
   const handleBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const handleLabel = new Gtk.Label({label : "Github handle"});
-  handleBox.append(handleLabel);
+  handleBox.prepend(handleLabel);
   const handleEntry = new Gtk.Entry();
   settings.bind('handle', handleEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
-  handleBox.prepend(handleEntry);
-  box.append(handleBox);
+  handleBox.append(handleEntry);
+  box.prepend(handleBox);
 
   const tokenBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const tokenLabel = new Gtk.Label({label : "Github Token"});
-  tokenBox.append(tokenLabel);
+  tokenBox.prepend(tokenLabel);
   const tokenEntry = new Gtk.Entry();
   settings.bind('token', tokenEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
-  tokenBox.prepend(tokenEntry);
-  box.append(tokenBox);
+  tokenBox.append(tokenEntry);
+  box.prepend(tokenBox);
 
   const domainBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const domainLabel = new Gtk.Label({label : "Github Hostname"});
-  domainBox.append(domainLabel);
+  domainBox.prepend(domainLabel);
   const domainEntry = new Gtk.Entry();
   settings.bind('domain', domainEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
-  domainBox.prepend(domainEntry);
-  box.append(domainBox);
+  domainBox.append(domainEntry);
+  box.prepend(domainBox);
 
   const explainerLabel = new Gtk.Label({label : TOKEN_EXPLAINER, selectable: true, 'use-markup': true});
-  box.prepend(explainerLabel);
+  box.append(explainerLabel);
 
   return box;
 }

--- a/prefs.js
+++ b/prefs.js
@@ -91,6 +91,9 @@ function buildPrefsWidget() {
   const explainerLabel = new Gtk.Label({label : TOKEN_EXPLAINER, selectable: true, 'use-markup': true});
   box.append(explainerLabel);
 
+  if (box.show_all) {
+    box.show_all();
+  }
   return box;
 }
 

--- a/prefs.js
+++ b/prefs.js
@@ -25,71 +25,71 @@ function buildPrefsWidget() {
 
   const hideWidgetBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const hideWidgetLabel = new Gtk.Label ({label : "Hide widget when there are no notifications"});
-  hideWidgetBox.pack_start(hideWidgetLabel, false, false, 5);
+  hideWidgetBox.append(hideWidgetLabel);
   const hideWidgetSwitch = new Gtk.Switch();
   settings.bind('hide-widget', hideWidgetSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
-  hideWidgetBox.pack_end(hideWidgetSwitch, false, false, 5);
-  box.pack_start(hideWidgetBox, false, false, 5);
+  hideWidgetBox.prepend(hideWidgetSwitch);
+  box.append(hideWidgetBox);
 
   const hideCount = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const hideCountLabel = new Gtk.Label ({label : "Hide notification count"});
-  hideCount.pack_start(hideCountLabel, false, false, 5);
+  hideCount.append(hideCountLabel);
   const hideCountSwitch = new Gtk.Switch();
   settings.bind('hide-notification-count', hideCountSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
-  hideCount.pack_end(hideCountSwitch, false, false, 5);
-  box.pack_start(hideCount, false, false, 5);
+  hideCount.prepend(hideCountSwitch);
+  box.append(hideCount);
 
   const showParticipating = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const showParticipatingLabel = new Gtk.Label ({label : "Only count notifications if you're participating (mention, review asked...)"});
-  showParticipating.pack_start(showParticipatingLabel, false, false, 5);
+  showParticipating.append(showParticipatingLabel);
   const showParticipatingSwitch = new Gtk.Switch();
   settings.bind('show-participating-only', showParticipatingSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
-  showParticipating.pack_end(showParticipatingSwitch, false, false, 5);
-  box.pack_start(showParticipating, false, false, 5);
+  showParticipating.prepend(showParticipatingSwitch);
+  box.append(showParticipating);
 
   const refreshInterval = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const refreshIntervalLabel = new Gtk.Label ({label : "Refresh interval (in seconds)*"});
-  refreshInterval.pack_start(refreshIntervalLabel, false, false, 5);
+  refreshInterval.append(refreshIntervalLabel);
   const refreshIntervalSpinButton = Gtk.SpinButton.new_with_range (60, 86400, 1);
   settings.bind('refresh-interval', refreshIntervalSpinButton, 'value', Gio.SettingsBindFlags.DEFAULT);
-  refreshInterval.pack_end(refreshIntervalSpinButton, false, false, 5);
-  box.pack_start(refreshInterval, false, false, 5);
+  refreshInterval.prepend(refreshIntervalSpinButton);
+  box.append(refreshInterval);
 
   // Show Alert
   const showAlert = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const showAlertLabel = new Gtk.Label ({label : "Show notifications alert"});
-  showAlert.pack_start(showAlertLabel, false, false, 5);
+  showAlert.append(showAlertLabel);
   const showAlertSwitch = new Gtk.Switch();
   settings.bind('show-alert', showAlertSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
-  showAlert.pack_end(showAlertSwitch, false, false, 5);
-  box.pack_start(showAlert, false, false, 5);
+  showAlert.prepend(showAlertSwitch);
+  box.append(showAlert);
 
   const handleBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const handleLabel = new Gtk.Label ({label : "Github handle"});
-  handleBox.pack_start(handleLabel, false, false, 5);
+  handleBox.append(handleLabel);
   const handleEntry = new Gtk.Entry();
   settings.bind('handle', handleEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
-  handleBox.pack_end(handleEntry, true, true, 5);
-  box.pack_start(handleBox, false, false, 5);
+  handleBox.prepend(handleEntry);
+  box.append(handleBox);
 
   const tokenBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const tokenLabel = new Gtk.Label ({label : "Github Token"});
-  tokenBox.pack_start(tokenLabel, false, false, 5);
+  tokenBox.append(tokenLabel);
   const tokenEntry = new Gtk.Entry();
   settings.bind('token', tokenEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
-  tokenBox.pack_end(tokenEntry, true, true, 5);
-  box.pack_start(tokenBox, false, false, 5);
+  tokenBox.prepend(tokenEntry);
+  box.append(tokenBox);
 
   const domainBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
   const domainLabel = new Gtk.Label ({label : "Github Hostname"});
-  domainBox.pack_start(domainLabel, false, false, 5);
+  domainBox.append(domainLabel);
   const domainEntry = new Gtk.Entry();
   settings.bind('domain', domainEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
-  domainBox.pack_end(domainEntry, true, true, 5);
-  box.pack_start(domainBox, false, false, 5);
+  domainBox.prepend(domainEntry);
+  box.append(domainBox);
 
   const explainerLabel = new Gtk.Label({label : TOKEN_EXPLAINER, selectable: true, 'use-markup': true});
-  box.pack_end(explainerLabel, false, false, 5);
+  box.prepend(explainerLabel);
 
   box.show_all();
   return box;

--- a/prefs.js
+++ b/prefs.js
@@ -24,7 +24,7 @@ function buildPrefsWidget() {
   const box = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL, spacing: 5});
 
   const hideWidgetBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
-  const hideWidgetLabel = new Gtk.Label ({label : "Hide widget when there are no notifications"});
+  const hideWidgetLabel = new Gtk.Label({label : "Hide widget when there are no notifications"});
   hideWidgetBox.append(hideWidgetLabel);
   const hideWidgetSwitch = new Gtk.Switch();
   settings.bind('hide-widget', hideWidgetSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
@@ -32,7 +32,7 @@ function buildPrefsWidget() {
   box.append(hideWidgetBox);
 
   const hideCount = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
-  const hideCountLabel = new Gtk.Label ({label : "Hide notification count"});
+  const hideCountLabel = new Gtk.Label({label : "Hide notification count"});
   hideCount.append(hideCountLabel);
   const hideCountSwitch = new Gtk.Switch();
   settings.bind('hide-notification-count', hideCountSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
@@ -40,7 +40,7 @@ function buildPrefsWidget() {
   box.append(hideCount);
 
   const showParticipating = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
-  const showParticipatingLabel = new Gtk.Label ({label : "Only count notifications if you're participating (mention, review asked...)"});
+  const showParticipatingLabel = new Gtk.Label({label : "Only count notifications if you're participating (mention, review asked...)"});
   showParticipating.append(showParticipatingLabel);
   const showParticipatingSwitch = new Gtk.Switch();
   settings.bind('show-participating-only', showParticipatingSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
@@ -48,7 +48,7 @@ function buildPrefsWidget() {
   box.append(showParticipating);
 
   const refreshInterval = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
-  const refreshIntervalLabel = new Gtk.Label ({label : "Refresh interval (in seconds)*"});
+  const refreshIntervalLabel = new Gtk.Label({label : "Refresh interval (in seconds)*"});
   refreshInterval.append(refreshIntervalLabel);
   const refreshIntervalSpinButton = Gtk.SpinButton.new_with_range (60, 86400, 1);
   settings.bind('refresh-interval', refreshIntervalSpinButton, 'value', Gio.SettingsBindFlags.DEFAULT);
@@ -57,7 +57,7 @@ function buildPrefsWidget() {
 
   // Show Alert
   const showAlert = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
-  const showAlertLabel = new Gtk.Label ({label : "Show notifications alert"});
+  const showAlertLabel = new Gtk.Label({label : "Show notifications alert"});
   showAlert.append(showAlertLabel);
   const showAlertSwitch = new Gtk.Switch();
   settings.bind('show-alert', showAlertSwitch, 'state', Gio.SettingsBindFlags.DEFAULT);
@@ -65,7 +65,7 @@ function buildPrefsWidget() {
   box.append(showAlert);
 
   const handleBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
-  const handleLabel = new Gtk.Label ({label : "Github handle"});
+  const handleLabel = new Gtk.Label({label : "Github handle"});
   handleBox.append(handleLabel);
   const handleEntry = new Gtk.Entry();
   settings.bind('handle', handleEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
@@ -73,7 +73,7 @@ function buildPrefsWidget() {
   box.append(handleBox);
 
   const tokenBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
-  const tokenLabel = new Gtk.Label ({label : "Github Token"});
+  const tokenLabel = new Gtk.Label({label : "Github Token"});
   tokenBox.append(tokenLabel);
   const tokenEntry = new Gtk.Entry();
   settings.bind('token', tokenEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
@@ -81,7 +81,7 @@ function buildPrefsWidget() {
   box.append(tokenBox);
 
   const domainBox = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL, spacing: 5});
-  const domainLabel = new Gtk.Label ({label : "Github Hostname"});
+  const domainLabel = new Gtk.Label({label : "Github Hostname"});
   domainBox.append(domainLabel);
   const domainEntry = new Gtk.Entry();
   settings.bind('domain', domainEntry, 'text', Gio.SettingsBindFlags.DEFAULT);
@@ -91,7 +91,6 @@ function buildPrefsWidget() {
   const explainerLabel = new Gtk.Label({label : TOKEN_EXPLAINER, selectable: true, 'use-markup': true});
   box.prepend(explainerLabel);
 
-  box.show_all();
   return box;
 }
 


### PR DESCRIPTION
The bare minimum to support Gnome 40. This means, for example, there still are UI inconsistencies, but the main functionality seems to be OK. Should close #32.