### PR TITLE
Make notifications length label theme-agnostic vertically-centered

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -112,7 +112,6 @@ class GithubNotifications {
             text: '' + this.notifications.length,
             style_class: 'system-status-icon notifications-length',
             y_align: Clutter.ActorAlign.CENTER,
-            x_expand: true,
             y_expand: true,
         });
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,4 +1,3 @@
 .notifications-length {
-	padding-left: 0;
-	padding-top: 4px;
+	padding: 0 inherit 0 0;
 }


### PR DESCRIPTION
As I tested, for my Gnome Shell theme, the notifications is not centered, because of the `padding-top` being set wrt default theme. Fix this.