### PR TITLE
set the extension compatible with gnome shell 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,5 +2,5 @@
 	"description": "Integrate Github's notifications within the gnome desktop environment\nSource code is available here: https://github.com/alexduf/gnome-github-notifications",
 	"uuid": "github.notifications@alexandre.dufournet.gmail.com",
 	"name": "Github Notifications",
-	"shell-version": ["40", "41"]
+	"shell-version": ["40", "41", "42"]
 }


### PR DESCRIPTION
successfully tested under
GNOME Shell 42.0
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04 LTS
Release:	22.04
Codename:	jammy