### PR TITLE
Notification improvements

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -275,7 +275,7 @@ class GithubNotifications {
             notification.update(title, message, { clear: true });
         }
 
-        this._source.notify(notification);
+        this._source.showNotification(notification);
     }
 
     addNotificationSource() {

--- a/extension.js
+++ b/extension.js
@@ -36,6 +36,7 @@ class GithubNotifications {
         this.showParticipatingOnly = false;
         this._source = null;
         this.settings = null;
+        this.icon = null;
     }
 
     interval() {
@@ -117,12 +118,12 @@ class GithubNotifications {
 
         this.checkVisibility();
 
-        let icon = new St.Icon({
+        this.icon = new St.Icon({
             style_class: 'system-status-icon'
         });
-        icon.gicon = Gio.icon_new_for_string(`${Me.path}/github.svg`);
+        this.icon.gicon = Gio.icon_new_for_string(`${Me.path}/github.svg`);
 
-        this.box.add_actor(icon);
+        this.box.add_actor(this.icon);
         this.box.add_actor(this.label);
 
         this.box.connect('button-press-event', (_, event) => {
@@ -265,7 +266,7 @@ class GithubNotifications {
         this.addNotificationSource();
 
         if (this._source && this._source.notifications.length == 0) {
-            notification = new MessageTray.Notification(this._source, title, message);
+            notification = new MessageTray.Notification(this._source, title, message, { gicon: this.icon.gicon });
 
             notification.setTransient(false);
             notification.setResident(false);

--- a/extension.js
+++ b/extension.js
@@ -267,7 +267,7 @@ class GithubNotifications {
         if (this._source && this._source.notifications.length == 0) {
             notification = new MessageTray.Notification(this._source, title, message);
 
-            notification.setTransient(true);
+            notification.setTransient(false);
             notification.setResident(false);
             notification.connect('activated', this.showBrowserUri.bind(this)); // Open on click
         } else {


### PR DESCRIPTION
This PR introduces some improvement in the notification alert. In particular:

- Makes the functionality work again. The API `Source.notify()` used to send the notification was in fact [deprecated in Gnome 3.38](https://github.com/GNOME/gnome-shell/blob/3.38.6/js/ui/messageTray.js#L790-L803) and [has been removed](https://github.com/GNOME/gnome-shell/blob/40.0/js/ui/messageTray.js#L755-L776) thus the extension currently fails with the error `Expected type string for argument 'property_name' but got type GObject_Object`.
- Marks the notification as non-transient, so it can be viewed in the notification list.
- Adds the GitHub icon to the notification.
