### PR TITLE
Port libsoup3

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,5 +2,5 @@
 	"description": "Integrate Github's notifications within the gnome desktop environment\nSource code is available here: https://github.com/alexduf/gnome-github-notifications",
 	"uuid": "github.notifications@alexandre.dufournet.gmail.com",
 	"name": "Github Notifications",
-	"shell-version": ["40", "41", "42"]
+	"shell-version": ["40", "41", "42", "43"]
 }


### PR DESCRIPTION
I am currently on gnome shell 43.0 binded to libsoup3 gir on Debian and it works.
It also works on a Debian install with gnome-shell 42.4 binded to libsoup 2.4.

But there are blind spots in the error paths:
- in:
```
body = this.httpSession.send_and_read_finish(result, err);
                    if (!body) {
                        error('Body is null: ' + err);
```
I do not know if the err (a GError) is converted to a string properly on error, I guessed.
Also, the 'Body is null' prefix might not be the best.

- I converted blindly:
`error('result error: ' + JSON.stringify(response));`
to
`error('result error: ' + JSON.stringify(result));`
I do not know what a GAsyncResult stringified will become. The issue is I do not know how it worked before with a SoupMessage.


So it is in a "works for me" form. As those changes are specific to the libsoup3 code paths maybe it could be merged and those issues handled when those code paths are triggered.